### PR TITLE
Update 2020_library_evolution_report.bs

### DIFF
--- a/2020_library_evolution_report.bs
+++ b/2020_library_evolution_report.bs
@@ -344,4 +344,4 @@ The following papers were reviewed on the mailing list:
 * [[P1944R1]]: Add Constexpr Modifiers to Functions in `<cstring>` and `<cwchar>`
 * [[P1924R0]]: Making `std::stack` constexpr
 * [[P1925R0]]: Making `std::queue` constexpr
-* [[P1926R0]]: Making `std::queue` constexpr
+* [[P1926R0]]: Making `std::priority_queue` constexpr

--- a/papers_processed.md
+++ b/papers_processed.md
@@ -54,5 +54,5 @@ Mailing List:
 * P2146R2: Modern std::byte stream IO for C++
 * P1924R0: Making std::stack constexpr
 * P1925R0: Making std::queue constexpr
-* P1926R0: Making std::queue constexpr
+* P1926R0: Making std::priority_queue constexpr
 


### PR DESCRIPTION
Fix wrong P1926R0 reference description (std::queue -> std::priority_queue)